### PR TITLE
Use html unicode entities instead of arbitrary placeholders

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -17,8 +17,6 @@ namespace Chefkoch\Morphoji;
 class Converter
 {
 
-    const DELIMITER = ':';
-
     /** @var string */
     private static $emojiPattern;
     /** @var string */

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -140,7 +140,7 @@ class Converter
      * Returns an array with all unicode values for emoji characters.
      *
      * This is a function so the array can be defined with a mix of hex values
-     * and range() calls to conveniently meintain the array with information
+     * and range() calls to conveniently maintain the array with information
      * from the official Unicode tables (where values are given in hex as well).
      *
      * With PHP > 5.6 this could be done in class variable, maybe even a

--- a/src/Text.php
+++ b/src/Text.php
@@ -31,11 +31,10 @@ class Text
      * Text constructor.
      *
      * @param string $text
-     * @param string $prefix optional, default is 'emoji'
      */
-    public function __construct($text, $prefix = 'emoji')
+    public function __construct($text)
     {
-        $this->converter = new Converter($prefix);
+        $this->converter = new Converter();
         $this->text = $text;
     }
 
@@ -48,7 +47,7 @@ class Text
     {
         if (null === $this->textPlaceholders) {
             $this->textPlaceholders =
-                $this->converter->emojiToPlaceholders($this->text);
+                $this->converter->emojiToEntities($this->text);
         }
 
         return $this->textPlaceholders;
@@ -63,7 +62,7 @@ class Text
     {
         if (null === $this->textEmoji) {
             $text = $this->getWithPlaceholders();
-            $this->textEmoji = $this->converter->placeholdersToEmoji($text);
+            $this->textEmoji = $this->converter->entitiesToEmoji($text);
         }
 
         return $this->textEmoji;

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -10,18 +10,16 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
     /** @var Converter */
     private $converter;
 
-    private $prefix = 'test';
-
     protected function setUp() {
-        $this->converter = new Converter($this->prefix);
+        $this->converter = new Converter();
     }
 
     public function variantEmojiProvider()
     {
         return [
-            'tm'       => ['00002122', '™️', '0000fe0f'],
-            'skull'    => ['00002620', '☠️', '0000fe0f'],
-            'up_arrow' => ['00002b06', '⬆️', '0000fe0f'],
+            'tm'       => ['™️', '2122', 'fe0f'],
+            'skull'    => ['☠️', '2620', 'fe0f'],
+            'up_arrow' => ['⬆️', '2b06', 'fe0f'],
         ];
     }
 
@@ -35,8 +33,8 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
     public function simpleEmojiProvider()
     {
         return [
-            'penguin'           => ['id' => '0001f427', 'char' => '🐧'],
-            'crying_w_laughter' => ['id' => '0001f602', 'char' => '😂'],
+            'penguin'           => ['1f427', '🐧'],
+            'crying_w_laughter' => ['1f602', '😂'],
         ];
 
     }
@@ -45,29 +43,29 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
      * @dataProvider variantEmojiProvider
      * @param string $charId
      * @param string $char
-     * @param string $modifierId
+     * @param string $modId
      */
-    public function testConvertEmojiVariantToPlaceholder($charId, $char, $modifierId)
+    public function testConvertEmojiVariantToPlaceholder($char, $charId, $modId)
     {
         $text = "Happy new year!";
-        $expect = "$text :$this->prefix-$charId::$this->prefix-$modifierId:";
+        $expect = "$text &#x{$charId};&#x{$modId};";
 
-        $this->assertEquals($expect, $this->converter->emojiToPlaceholders("$text $char"));
+        $this->assertEquals($expect, $this->converter->emojiToEntities("$text $char"));
     }
 
     /**
      * @dataProvider variantEmojiProvider
      * @param string $charId
      * @param string $char
-     * @param string $modifierId
+     * @param string $modId
      */
-    public function testConvertPlaceholderToEmojiVariant($charId, $char, $modifierId)
+    public function testConvertPlaceholderToEmojiVariant($char, $charId, $modId)
     {
         $text = "Happy new year!";
         $expect = "$text $char";
-        $placeholders = "$text :$this->prefix-$charId::$this->prefix-$modifierId:";
+        $placeholders= "$text &#x{$charId};&#x{$modId};";
 
-        $this->assertEquals($expect, $this->converter->placeholdersToEmoji($placeholders));
+        $this->assertEquals($expect, $this->converter->entitiesToEmoji($placeholders));
     }
 
     /**
@@ -75,12 +73,12 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
      * @param string $char
      * @dataProvider simpleEmojiProvider
      */
-    public function testConvertSimpleEmojiToPlacesholder($id, $char)
+    public function testConvertSimpleEmojiToPlaceholder($id, $char)
     {
         $text = "Dearly departed ...";
-        $expect = "$text :$this->prefix-$id:";
+        $expect = "$text &#x$id;";
 
-        $this->assertEquals($expect, $this->converter->emojiToPlaceholders("$text $char"));
+        $this->assertEquals($expect, $this->converter->emojiToEntities("$text $char"));
     }
 
     /**
@@ -92,8 +90,8 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
     {
         $text = "Dearly departed ...";
         $expect = "$text $char";
-        $placeholders = "$text :$this->prefix-$id:";
+        $placeholders = "$text &#x$id;";
 
-        $this->assertEquals($expect, $this->converter->placeholdersToEmoji($placeholders));
+        $this->assertEquals($expect, $this->converter->entitiesToEmoji($placeholders));
     }
 }

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -9,11 +9,11 @@ class TextTest extends \PHPUnit_Framework_TestCase
 
     public function testSimpleEmojiAsPlaceholders() {
         $text = new Text("Whoohoo 🐧");
-        $this->assertEquals("Whoohoo :emoji-0001f427:", $text->getWithPlaceholders());
+        $this->assertEquals("Whoohoo &#x1f427;", $text->getWithPlaceholders());
     }
 
     public function testSimpleEmojiAsUnicode() {
-        $text = new Text("Whoohoo :emoji-0001f427:");
+        $text = new Text("Whoohoo &#x1f427;");
         $this->assertEquals("Whoohoo 🐧", $text->getWithEmoji());
     }
 }


### PR DESCRIPTION
Use unicode html entities instead of arbitrary placeholders internally.

If the data is output by a source which doesn't (yet) do the convert back to UTF-8 and it is displayed somewhere where html entities can be rendered, the user won't see arcane placeholders but what he expects to see.